### PR TITLE
Honeytrap JSON logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ RUN apt-get update -y && \
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install packages
-RUN apt-get install -y supervisor iptables git build-essential autoconf libnetfilter-queue1 libnetfilter-queue-dev libtool libpq5 libpq-dev
+RUN apt-get install -y supervisor iptables git build-essential autoconf libnetfilter-queue1 libnetfilter-queue-dev libjson-c-dev libtool libpq5 libpq-dev
 
 # Install honeytrap from source
-RUN cd /root/ && git clone https://github.com/armedpot/honeytrap && \
-    cd /root/honeytrap/ && autoreconf -fi && ./configure --with-stream-mon=nfq --with-logattacker --prefix=/opt/honeytrap && make && make install 
+RUN cd /root/ && git clone -b json-logging https://github.com/adepasquale/honeytrap && \
+    cd /root/honeytrap/ && autoreconf -fi && ./configure --with-stream-mon=nfq --with-logattacker --with-logjson --prefix=/opt/honeytrap && make && make install
 
 # Setup user, groups and configs
 RUN addgroup --gid 2000 tpot && \

--- a/honeytrap.conf
+++ b/honeytrap.conf
@@ -85,8 +85,8 @@ plugin-SpamSum = {
 
 plugin-logAttacker = { logfile = "/data/honeytrap/log/attacker.log" }
 
-
-
+// log attack details in JSON format
+plugin-logJSON = { logfile = "/opt/honeytrap/attackers.json" }
 
 
 // store attacks in PostgeSQL database


### PR DESCRIPTION
Hello,
I have added a Honeytrap module providing JSON output for incoming attacks.

The module uses the [`json-c` library](https://github.com/json-c/json-c) (Ubuntu package `libjson-c-dev`) to output data with the same format of the [`Attack` struct](https://github.com/armedpot/honeytrap/blob/7aee29cfb424b077cf702a2aa31c231df98513ad/src/attack.h#L18-L58) (and related).

**WARNING: the module has not been extensively tested yet.** For now, this pull request is meant for you to test the new JSON module. Once `adepasquale/honeytrap` is well tested and hopefully merged upstream, it would better to switch back to the original `armedpot/honeytrap` repository.